### PR TITLE
Implement the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,17 @@
 [package]
 name = "qed"
 version = "0.0.1"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+license = "MIT"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+readme = "README.md"
+repository = "https://github.com/artichoke/qed"
+documentation = "https://docs.rs/qed"
+homepage = "https://github.com/artichoke/qed"
+description = "Compile-time assertions"
+keywords = ["assert", "const", "no_std", "static"]
+categories = ["no-std", "rust-patterns"]
+include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# qed
+
+[![GitHub Actions](https://github.com/artichoke/qed/workflows/CI/badge.svg)](https://github.com/artichoke/qed/actions)
+[![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
+[![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
+<br>
+[![Crate](https://img.shields.io/crates/v/qed.svg)](https://crates.io/crates/qed)
+[![API](https://docs.rs/qed/badge.svg)](https://docs.rs/qed)
+[![API trunk](https://img.shields.io/badge/docs-trunk-blue.svg)](https://artichoke.github.io/qed/qed/)
+
+Compile time assertions.
+
+> **_QED_** is an initialism of the Latin phrase **_quod erat demonstrandum_**,
+> meaning "which was to be demonstrated".
+
+This crate contains compile time assertion macros used for maintaining safety
+invariants or limiting platform support. If the assertion is false, a compiler
+error is emitted.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+qed = "0.0.1"
+```
+
+Then make compile time assertions like:
+
+```rust
+use core::num::NonZeroU8;
+
+qed::const_assert!(u32::BITS <= usize::BITS);
+qed::const_assert_eq!("Veni, vidi, vici".len(), "Cogito, ergo sum".len());
+qed::const_assert_ne!('∎'.len_utf8(), 0);
+qed::const_assert_matches!(NonZeroU8::new(42), Some(_));
+```
+
+## `no_std`
+
+qed is `no_std` compatible.
+
+### Minimum Supported Rust Version
+
+This crate requires at least Rust 1.56.0. This version can be bumped in minor
+releases.
+
+## License
+
+`qed` is licensed under the [MIT License](LICENSE) (c) Ryan Lopopolo.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,174 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![cfg_attr(test, allow(clippy::non_ascii_literal))]
+#![cfg_attr(test, allow(clippy::shadow_unrelated))]
+#![allow(unknown_lints)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+#![warn(rust_2018_idioms)]
+#![warn(trivial_casts, trivial_numeric_casts)]
+#![warn(unused_qualifications)]
+#![warn(variant_size_differences)]
+#![forbid(unsafe_code)]
+// Enable feature callouts in generated documentation:
+// https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html
+//
+// This approach is borrowed from tokio.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
+
+//! Compile time assertions.
+//!
+//! This crate contains compile time assertion macros used for maintaining safety
+//! invariants or limiting platform support. If the assertion is false, a compiler
+//! error is emitted.
+//!
+//! # Examples
+//!
+//! ```
+//! # use core::num::NonZeroU8;
+//! # #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+//! qed::const_assert!(u32::BITS <= usize::BITS);
+//! qed::const_assert_eq!("Veni, vidi, vici".len(), "Cogito, ergo sum".len());
+//! qed::const_assert_ne!('∎'.len_utf8(), 0);
+//! qed::const_assert_matches!(NonZeroU8::new(42), Some(_));
+//! ```
+//!
+//!
+//! Assertion failures will result in a compile error:
+//!
+//! ```compile_fail
+//! qed::const_assert!("non-empty string".is_empty());
+//! ```
+
+#![no_std]
+#![doc(html_root_url = "https://docs.rs/qed/0.0.1")]
+
+// Ensure code blocks in README.md compile
+#[cfg(all(doctest, any(target_pointer_width = "32", target_pointer_width = "64")))]
+#[doc = include_str!("../README.md")]
+mod readme {}
+
+/// Asserts that a boolean expression is true at compile time.
+///
+/// This will result in a compile time type error if the boolean expression does
+/// not evaluate to true.
+///
+/// # Uses
+///
+/// Assertions are always checked in both debug and release builds and cannot be
+/// disabled.
+///
+/// Unsafe code and [`as` casts][casts] may rely on `const_assert!` to enforce
+/// runtime invariants that, if violated, could lead to unsafety.
+///
+/// [casts]: https://doc.rust-lang.org/nomicon/casts.html
+///
+/// Other use-cases of `const_assert!` include limiting supported platforms and
+/// architectures.
+///
+/// # Examples
+///
+/// ```
+/// // Assert at compile time that the target platform has at least 32-bit
+/// // `usize`.
+/// # #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+/// qed::const_assert!(u32::BITS <= usize::BITS);
+/// ```
+///
+/// Assertion failures will result in a compile error:
+///
+/// ```compile_fail
+/// qed::const_assert!("non-empty string".is_empty());
+/// ```
+#[macro_export]
+macro_rules! const_assert {
+    ($x:expr $(,)?) => {
+        #[allow(unknown_lints, clippy::eq_op)]
+        const _: [(); 0 - !{
+            const ASSERT: bool = $x;
+            ASSERT
+        } as usize] = [];
+    };
+}
+
+/// Asserts that two expressions are equal to each other (using [`PartialEq`])
+/// at compile time.
+///
+/// See also [`const_assert!`].
+///
+/// # Examples
+///
+/// ```
+/// qed::const_assert_eq!("Veni, vidi, vici".len(), "Cogito, ergo sum".len());
+/// ```
+///
+/// The following fails to compile because the expressions are not equal:
+///
+/// ```compile_fail
+/// qed::const_assert_eq!("Carpe diem".len(), "Et tu, Brute?".len());
+/// ```
+#[macro_export]
+macro_rules! const_assert_eq {
+    ($x:expr, $y:expr $(,)?) => {
+        $crate::const_assert!($x == $y);
+    };
+}
+
+/// Asserts that two expressions are not equal to each other (using
+/// [`PartialEq`]) at compile time.
+///
+/// See also [`const_assert!`].
+///
+/// # Examples
+///
+/// ```
+/// const END_OF_PROOF: char = '∎';
+/// qed::const_assert_ne!(END_OF_PROOF.len_utf8(), 0);
+/// ```
+///
+/// The following fails to compile because the expressions are equal:
+///
+/// ```compile_fail
+/// const END_OF_PROOF: char = '∎';
+/// qed::const_assert_ne!(END_OF_PROOF.len_utf8(), 3);
+/// ```
+#[macro_export]
+macro_rules! const_assert_ne {
+    ($x:expr, $y:expr $(,)?) => {
+        $crate::const_assert!($x != $y);
+    };
+}
+
+/// Asserts that an expression matches any of the given patterns at compile
+/// time.
+///
+/// Like in a `match` expression, the pattern can be optionally followed by `if`
+/// and a guard expression that has access to names bound by the pattern.
+///
+/// See also [`const_assert!`].
+///
+/// # Examples
+///
+/// ```
+/// # use core::num::NonZeroU8;
+/// qed::const_assert_matches!(NonZeroU8::new(0), None);
+/// qed::const_assert_matches!(NonZeroU8::new(42), Some(_));
+/// ```
+///
+/// Assertion failures will result in a compile error:
+///
+/// ```compile_fail
+/// qed::const_assert_matches!(b"maybe c string".last(), Some(&0));
+/// ```
+#[macro_export]
+macro_rules! const_assert_matches {
+    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
+        $crate::const_assert!(match $left {
+            $( $pattern )|+ $( if $guard )? => true,
+            _ => false,
+        });
+    };
 }


### PR DESCRIPTION
Implement the crate with a macro-based API:

- `qed::const_assert!`
- `qed::const_assert_eq!`
- `qed::const_assert_neq!`
- `qed::const_assert_matches!`
- `qed::lossless_cast_u32_to_usize!`

Add docs, README, cargo metadata.