### PR TITLE
Release v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qed"
-version = "0.0.1"
+version = "1.0.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qed = "0.0.1"
+qed = "1.0.0"
 ```
 
 Then make compile time assertions like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/qed/0.0.1")]
+#![doc(html_root_url = "https://docs.rs/qed/1.0.0")]
 
 // Ensure code blocks in README.md compile
 #[cfg(all(doctest, any(target_pointer_width = "32", target_pointer_width = "64")))]


### PR DESCRIPTION
Release `qed` 1.0.0.

[`qed` is published on crates.io](https://crates.io/crates/qed/1.0.0).

`qed` provides implementations of compile time asserts and helpers for asserting invariants in unsafe code.

`qed` is a `no_std` crate.