### PR TITLE
Add compile time macros for `CStr`s

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         run: cargo test --no-default-features
 
   build-msrv:
-    name: Build (1.56.0)
+    name: Build (1.59.0)
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0
@@ -59,7 +59,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.56.0"
+          toolchain: "1.59.0"
           profile: minimal
 
       - name: Compile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         run: cargo test --no-default-features
 
   build-msrv:
-    name: Build (1.59.0)
+    name: Build (MSRV)
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qed"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qed = "1.1.0"
+qed = "1.2.0"
 ```
 
 Then make compile time assertions like:
@@ -39,11 +39,12 @@ qed::const_assert_matches!(NonZeroU8::new(42), Some(_));
 
 ## `no_std`
 
-qed is `no_std` compatible.
+qed is `no_std` compatible although some macros may construct types which
+require `::std` to be available.
 
 ### Minimum Supported Rust Version
 
-This crate requires at least Rust 1.56.0. This version can be bumped in minor
+This crate requires at least Rust 1.59.0. This version can be bumped in minor
 releases.
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/qed/1.2.0")]
 
-#[cfg(test)]
+#[cfg(any(test, doc))]
 extern crate std;
 
 // Ensure code blocks in README.md compile
@@ -298,6 +298,8 @@ macro_rules! const_assert_bytes_has_no_nul {
 /// Construct a const [`CStr`] from the given bytes at compile time and assert
 /// that the given bytes are a valid `CStr` (NUL terminated with no interior NUL
 /// bytes).
+///
+/// [`CStr`]: std::ffi::CStr
 ///
 /// This macro emits a compile error if the given slice contains any interior
 /// NUL bytes or does not have a NUL terminator.


### PR DESCRIPTION
Add `const_assert_bytes_has_no_nul!` to assert that a byte slice has no
NUL bytes (either interior or terminating).

Add `const_cstr_from_bytes!` to construct a `&'static CStr` from a const
byte slice. A compile time assertion makes sure the invariants of
`CStr::from_bytes_with_nul_unchecked` are met and then constructs the
`CStr` from the bytes.

Raise MSRV to 1.59.0 which is when `CStr::from_bytes_with_nul_unchecked`
became const stable.

Bump crate version to v1.2.0.