### PR TITLE
Add a `str` version of `const_cstr_from_bytes!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qed"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qed = "1.2.0"
+qed = "1.3.0"
 ```
 
 Then make compile time assertions like:


### PR DESCRIPTION
For improved ergonomics when constructing consts, add a new macro
`qed::const_cstr_from_str!` which takes a const `&str` argument.

String slices are easier to construct inline to the macro than byte
slices which may require an intermediate constant to do the slice
coercion.

Prepare for v1.3.0 release.