### PR TITLE
Extract `find` and `is_cstr` const fn to an inner `imp` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qed"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qed = "1.3.0"
+qed = "1.3.1"
 ```
 
 Then make compile time assertions like:

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -1,0 +1,55 @@
+#[must_use]
+pub const fn find(slice: &[u8], elem: u8) -> Option<usize> {
+    let mut idx = 0;
+    loop {
+        if idx == slice.len() {
+            return None;
+        }
+        if slice[idx] == elem {
+            return Some(idx);
+        }
+        idx += 1;
+    }
+}
+
+#[must_use]
+pub const fn is_cstr(slice: &[u8]) -> bool {
+    matches!(find(slice, 0), Some(nul_pos) if nul_pos + 1 == slice.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find, is_cstr};
+
+    #[test]
+    fn find_nul_byte() {
+        assert_eq!(find(b"", 0), None);
+        assert_eq!(find(b"abc", 0), None);
+        assert_eq!(find(b"abc\xFFxyz", 0), None);
+
+        assert_eq!(find(b"abc\0xyz", 0), Some(3));
+        assert_eq!(find(b"abc\0xyz\0", 0), Some(3));
+        assert_eq!(find(b"abc\xFF\0xyz", 0), Some(4));
+        assert_eq!(find(b"abc\xFF\0xyz\0", 0), Some(4));
+
+        assert_eq!(find(b"\0", 0), Some(0));
+        assert_eq!(find(b"abc\0", 0), Some(3));
+        assert_eq!(find(b"abc\xFFxyz\0", 0), Some(7));
+    }
+
+    #[test]
+    fn check_is_cstr() {
+        assert!(!is_cstr(b""));
+        assert!(!is_cstr(b"abc"));
+        assert!(!is_cstr(b"abc\xFFxyz"));
+
+        assert!(!is_cstr(b"abc\0xyz"));
+        assert!(!is_cstr(b"abc\0xyz\0"));
+        assert!(!is_cstr(b"abc\xFF\0xyz"));
+        assert!(!is_cstr(b"abc\xFF\0xyz\0"));
+
+        assert!(is_cstr(b"\0"));
+        assert!(is_cstr(b"abc\0"));
+        assert!(is_cstr(b"abc\xFFxyz\0"));
+    }
+}


### PR DESCRIPTION
Prepare for v1.3.1 release.