### PR TITLE
Ensure macros work when builtin types like u8, bool, and str are shadowed

### DIFF
--- a/src/imp.rs
+++ b/src/imp.rs
@@ -26,6 +26,17 @@ pub const fn contains_nul(slice: &[u8]) -> bool {
     matches!(find(slice, 0), Some(_))
 }
 
+pub mod types {
+    // Type alias for `u8`.
+    pub type Bool = bool;
+    // Type alias for `u8`.
+    pub type U8 = u8;
+    // Type alias for `usize`.
+    pub type Usize = usize;
+    // Type alias for `str`.
+    pub type Str = str;
+}
+
 #[cfg(test)]
 mod tests {
     use super::{contains_nul, find, is_cstr};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,9 @@ macro_rules! const_assert {
     ($x:expr $(,)?) => {
         #[allow(unknown_lints, clippy::eq_op)]
         const _: [(); 0 - !{
-            const ASSERT: bool = $x;
+            const ASSERT: $crate::imp::types::Bool = $x;
             ASSERT
-        } as usize] = [];
+        } as $crate::imp::types::Usize] = [];
     };
 }
 
@@ -280,7 +280,7 @@ macro_rules! const_assert_size_eq {
 #[macro_export]
 macro_rules! const_assert_bytes_has_no_nul {
     ($bytes:expr $(,)?) => {{
-        const _: &[u8] = $bytes;
+        const _: &[$crate::imp::types::U8] = $bytes;
 
         $crate::const_assert!(!$crate::imp::contains_nul($bytes));
     }};
@@ -336,7 +336,7 @@ macro_rules! const_assert_bytes_has_no_nul {
 #[macro_export]
 macro_rules! const_cstr_from_bytes {
     ($bytes:expr $(,)?) => {{
-        const _: &[u8] = $bytes;
+        const _: &[$crate::imp::types::U8] = $bytes;
 
         $crate::const_assert!($crate::imp::is_cstr($bytes));
 
@@ -400,8 +400,9 @@ macro_rules! const_cstr_from_bytes {
 #[macro_export]
 macro_rules! const_cstr_from_str {
     ($str:expr $(,)?) => {{
-        const STRING: &str = $str;
-        $crate::const_cstr_from_bytes!(STRING.as_bytes())
+        const _: &$crate::imp::types::Str = $str;
+
+        $crate::const_cstr_from_bytes!($str.as_bytes())
     }};
 }
 
@@ -509,5 +510,56 @@ mod tests {
         const None: () = ();
 
         crate::const_assert_bytes_has_no_nul!("abcdefg".as_bytes());
+    }
+
+    #[test]
+    fn const_assert_hygiene_bool() {
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct bool {}
+        crate::const_assert!("".is_empty());
+    }
+
+    #[test]
+    fn const_assert_hygiene_usize() {
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct usize {}
+        crate::const_assert!("".is_empty());
+    }
+
+    #[test]
+    fn const_cstr_from_bytes_hygiene() {
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct u8 {}
+        const _: &CStr = crate::const_cstr_from_str!("Abc\0");
+    }
+
+    #[test]
+    fn const_cstr_from_str_hygiene_str() {
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct str {}
+        const _: &CStr = crate::const_cstr_from_str!("Abc\0");
+    }
+
+    #[test]
+    fn const_cstr_from_str_hygiene_u8() {
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct u8 {}
+        const _: &CStr = crate::const_cstr_from_str!("Abc\0");
+    }
+
+    #[test]
+    fn const_cstr_from_str_hygiene_str_u8() {
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct str {}
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct u8 {}
+        const _: &CStr = crate::const_cstr_from_str!("Abc\0");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,14 @@ mod tests {
     }
 
     #[test]
+    fn const_assert_bytes_has_no_nul_hygiene() {
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct u8 {}
+        crate::const_assert_bytes_has_no_nul!("abcdefg".as_bytes());
+    }
+
+    #[test]
     fn const_assert_hygiene_bool() {
         #[allow(dead_code)]
         #[allow(non_camel_case_types)]


### PR DESCRIPTION
Using type aliases for builtin types exposed in imp module.

Closes #16.