### PR TITLE
Hygiene fixes for `lossless_cast_u32_to_usize!`

### DIFF
--- a/src/imp.rs
+++ b/src/imp.rs
@@ -26,6 +26,13 @@ pub const fn contains_nul(slice: &[u8]) -> bool {
     matches!(find(slice, 0), Some(_))
 }
 
+// Assert that `usize` is at least `u32` and cast the given `u32` to `usize`.
+#[must_use]
+pub const fn lossless_cast_u32_to_usize(num: u32) -> usize {
+    crate::const_assert!(usize::BITS >= u32::BITS);
+    num as usize
+}
+
 pub mod types {
     // Type alias for `u8`.
     pub type U8 = u8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,11 +214,9 @@ macro_rules! const_assert_matches {
 /// ```
 #[macro_export]
 macro_rules! lossless_cast_u32_to_usize {
-    ($num:expr) => {{
-        $crate::const_assert!(usize::BITS >= u32::BITS);
-        let num: u32 = $num;
-        num as usize
-    }};
+    ($num:expr) => {
+        $crate::imp::lossless_cast_u32_to_usize($num)
+    };
 }
 
 /// Asserts that two types have the same size at compile time.
@@ -541,6 +539,24 @@ mod tests {
         #[allow(non_camel_case_types)]
         struct usize {}
         crate::const_assert!("".is_empty());
+    }
+
+    #[test]
+    fn lossless_u32_to_usize_hygiene_u32() {
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct u32 {}
+        let n = crate::lossless_cast_u32_to_usize!(29_u32);
+        assert_eq!(n, 29_usize);
+    }
+
+    #[test]
+    fn lossless_u32_to_usize_hygiene_usize() {
+        #[allow(dead_code)]
+        #[allow(non_camel_case_types)]
+        struct usize {}
+        let n = crate::lossless_cast_u32_to_usize!(29_u32);
+        assert_eq!(n, 29_usize);
     }
 
     #[test]


### PR DESCRIPTION
Ensure the macro works when `u32` or `usize` are shadowed.