### PR TITLE
Add dummy core, std, and imp modules to qed tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,8 +404,12 @@ macro_rules! const_cstr_from_str {
 
 #[cfg(test)]
 mod tests {
-    use core::num::NonZeroU8;
-    use std::ffi::CStr;
+    use ::core::num::NonZeroU8;
+    use ::std::ffi::CStr;
+
+    mod core {}
+    mod std {}
+    mod imp {}
 
     #[test]
     fn const_assert_no_warnings() {


### PR DESCRIPTION
To check for more hygiene violations.