### PR TITLE
Release v1.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qed"
-version = "1.3.1"
+version = "1.4.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qed = "1.3.1"
+qed = "1.4.0"
 ```
 
 Then make compile time assertions like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/qed/1.3.1")]
+#![doc(html_root_url = "https://docs.rs/qed/1.4.0")]
 
 #[cfg(any(test, doc))]
 extern crate std;


### PR DESCRIPTION
Release 1.4.0 of qed.

[`qed` is available on crates.io](https://crates.io/crates/qed/1.4.0).

## Improvements

This release features many improvements to macro expansions to prevent conflicts with symbols in use at call sites, documentation, and tests:

- Add the cfg's to lossless cast u32 to usize tests. https://github.com/artichoke/qed/pull/13
- Improve examples in docs and README. https://github.com/artichoke/qed/pull/14
- Add a `contains_nul` const fn to `imp` module. https://github.com/artichoke/qed/pull/15
- Ensure macros work when builtin types like u8, bool, and str are shadowed. https://github.com/artichoke/qed/pull/17
- Use const assert from Rust 1.57.0. https://github.com/artichoke/qed/pull/18
- Use `::core::primitive` re-exports for macro hygiene. https://github.com/artichoke/qed/pull/20
- Add dummy core, std, and imp modules to qed tests. https://github.com/artichoke/qed/pull/21
- Fix doc and comment typos. https://github.com/artichoke/qed/pull/22