### PR TITLE
chore: Update `.github/workflows/audit.yaml` in `artichoke/qed`

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -30,6 +30,14 @@ jobs:
   rust:
     name: Audit Rust Dependencies
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
       - name: Checkout repository
@@ -59,11 +67,8 @@ jobs:
             cargo +stable generate-lockfile --verbose
           fi
 
-      - name: Setup cargo-deny
-        run: curl -sL "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.3/cargo-deny-0.11.3-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1
-
-      - name: Show cargo-deny version
-        run: cargo-deny --version
-
-      - name: Run cargo-deny
-        run: cargo-deny --locked check --show-stats
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          arguments: --locked --all-features
+          command: check ${{ matrix.checks }}
+          command-arguments: --show-stats


### PR DESCRIPTION
Managed by Terraform.

## Contents

```
---
name: Audit
"on":
  push:
    branches:
      - trunk
  pull_request:
    branches:
      - trunk
  schedule:
    - cron: "0 0 * * TUE"
jobs:
  ruby:
    name: Audit Ruby Dependencies
    runs-on: ubuntu-latest

    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Install Ruby toolchain
        uses: ruby/setup-ruby@v1
        with:
          ruby-version: ".ruby-version"
          bundler-cache: true

      - name: bundler-audit
        run: bundle exec bundle-audit check --update

  rust:
    name: Audit Rust Dependencies
    runs-on: ubuntu-latest
    strategy:
      matrix:
        checks:
          - advisories
          - bans licenses sources

    # Prevent sudden announcement of a new advisory from failing ci:
    continue-on-error: ${{ matrix.checks == 'advisories' }}

    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Install Rust toolchain
        run: |
          echo "::group::rustup toolchain install"
          rustup toolchain install stable --profile minimal
          echo "::endgroup::"
          echo "::group::set default toolchain"
          rustup default stable
          echo "::endgroup::"
          echo "::group::rustup version"
          rustup -Vv
          echo "::endgroup::"
          echo "::group::rustc version"
          rustc -Vv
          echo "::endgroup::"
          echo "::group::cargo version"
          cargo version --verbose
          echo "::endgroup::"

      - name: Generate Cargo.lock
        run: |
          if [[ ! -f "Cargo.lock" ]]; then
            cargo +stable generate-lockfile --verbose
          fi

      - uses: EmbarkStudios/cargo-deny-action@v1
        with:
          arguments: --locked --all-features
          command: check ${{ matrix.checks }}
          command-arguments: --show-stats
```