### PR TITLE
Address clippy lint violation `clippy::let_underscore_untyped` introduced in Rust 1.69.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ macro_rules! lossless_cast_u32_to_usize {
 macro_rules! const_assert_size_eq {
     ($left:ty, $right:ty $(,)?) => {
         const _: () = {
-            let _ = ::core::mem::transmute::<$left, $right>;
+            let _assert = ::core::mem::transmute::<$left, $right>;
         };
     };
 }


### PR DESCRIPTION
See:

- https://github.com/rust-lang/rust-clippy/pull/10442
- https://github.com/artichoke/artichoke/pull/2511
- https://github.com/artichoke/intaglio/pull/211