### PR TITLE
Prepare v1.5.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qed"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qed = "1.4.0"
+qed = "1.5.0"
 ```
 
 Then make compile time assertions like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/qed/1.4.0")]
+#![doc(html_root_url = "https://docs.rs/qed/1.5.0")]
 
 #[cfg(any(test, doc))]
 extern crate std;


### PR DESCRIPTION
Release 1.5.0 of qed.

[`qed` is available on crates.io](https://crates.io/crates/qed/1.5.0).

## Improvements

This release features improvements to packaging Rust best practices:

- Fix cargo deny license allow list for unicode-ident 1.0.2. https://github.com/artichoke/qed/pull/30
- Address clippy lint violation `clippy::let_underscore_untyped` introduced in Rust 1.69.0. https://github.com/artichoke/qed/pull/52

## Build

This release includes many upgrades to `qed`'s build process and development dependencies, such as:

- Ensure MSRV CI job overrides the active Rust version. https://github.com/artichoke/qed/pull/35
- Remove dependency on actions-rs organization GitHub Actions. https://github.com/artichoke/qed/pull/51

These updates do not impact code shipped to crates.io, but they ensure high code quality and minimal supply chain risk.