### PR TITLE
Prepare v1.6.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qed"
-version = "1.5.0"
+version = "1.6.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qed = "1.5.0"
+qed = "1.6.0"
 ```
 
 Then make compile time assertions like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/qed/1.5.0")]
+#![doc(html_root_url = "https://docs.rs/qed/1.6.0")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(doctest, any(target_pointer_width = "32", target_pointer_width = "64")))]


### PR DESCRIPTION
Release 1.6.0 of qed.

[`qed` is available on crates.io](https://crates.io/crates/qed/1.6.0).

## Improvements

This release features documentation improvements, true `no_std`, and an MSRV bump:

- Add cargo-spellcheck config and fix errors. https://github.com/artichoke/qed/pull/54
- Import `CStr` from `core`, raise MSRV to 1.64.0. https://github.com/artichoke/qed/pull/55