### PR TITLE
Add no-std, no-alloc crates.io category metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qed"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/qed"
 homepage = "https://github.com/artichoke/qed"
 description = "Compile-time assertions"
 keywords = ["assert", "const", "no_std", "static"]
-categories = ["no-std", "rust-patterns"]
+categories = ["no-std", "no-std::no-alloc", "rust-patterns"]
 include = ["src/**/*", "tests/**/*", "LICENSE", "README.md"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qed = "1.6.0"
+qed = "1.6.1"
 ```
 
 Then make compile time assertions like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! ```
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/qed/1.6.0")]
+#![doc(html_root_url = "https://docs.rs/qed/1.6.1")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(doctest, any(target_pointer_width = "32", target_pointer_width = "64")))]


### PR DESCRIPTION
Prepare for v1.6.1 release.