### PR TITLE
Do not run tests for MSRV build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,18 +63,6 @@ jobs:
       - name: Compile
         run: cargo build --verbose
 
-      - name: Compile tests
-        run: cargo test --no-run
-
-      - name: Test
-        run: cargo test
-
-      - name: Test with all features
-        run: cargo test --all-features
-
-      - name: Test with no default features
-        run: cargo test --no-default-features
-
   rust:
     name: Lint and format Rust
     runs-on: ubuntu-latest


### PR DESCRIPTION
MSRV conflicts with toml v0.7.x which is pulled in by `version-sync`.