### PR TITLE
Remove markdown link check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,24 +107,24 @@ running:
 
 ```console
 $ bundle exec rake --tasks
-rake build                        # Build Rust workspace
-rake bundle:audit:check           # Checks the Gemfile.lock for insecure dependencies
-rake bundle:audit:update          # Updates the bundler-audit vulnerability database
-rake doc                          # Generate Rust API documentation
-rake doc:open                     # Generate Rust API documentation and open it in a web browser
-rake fmt                          # Format sources
-rake fmt:rust                     # Format Rust sources with rustfmt
-rake fmt:text                     # Format text, YAML, and Markdown sources with prettier
-rake format                       # Format sources
-rake format:rust                  # Format Rust sources with rustfmt
-rake format:text                  # Format text, YAML, and Markdown sources with prettier
-rake lint                         # Lint sources
-rake lint:clippy                  # Lint Rust sources with Clippy
-rake lint:clippy:restriction      # Lint Rust sources with Clippy restriction pass (unenforced lints)
-rake lint:rubocop                 # Run RuboCop
-rake lint:rubocop:autocorrect     # Auto-correct RuboCop offenses
-rake release:markdown_link_check  # Check for broken links in markdown files
-rake test                         # Run qed unit tests
+rake build                         # Build Rust workspace
+rake bundle:audit:check            # Checks the Gemfile.lock for insecure dependencies
+rake bundle:audit:update           # Updates the bundler-audit vulnerability database
+rake doc                           # Generate Rust API documentation
+rake doc:open                      # Generate Rust API documentation and open it in a web browser
+rake fmt                           # Format sources
+rake fmt:rust                      # Format Rust sources with rustfmt
+rake fmt:text                      # Format text, YAML, and Markdown sources with prettier
+rake format                        # Format sources
+rake format:rust                   # Format Rust sources with rustfmt
+rake format:text                   # Format text, YAML, and Markdown sources with prettier
+rake lint                          # Lint sources
+rake lint:clippy                   # Lint Rust sources with Clippy
+rake lint:clippy:restriction       # Lint Rust sources with Clippy restriction pass (unenforced lints)
+rake lint:rubocop                  # Run RuboCop
+rake lint:rubocop:autocorrect      # Autocorrect RuboCop offenses (only when it's safe)
+rake lint:rubocop:autocorrect_all  # Autocorrect RuboCop offenses (safe and unsafe)
+rake test                          # Run qed unit tests
 ```
 
 To lint Ruby sources, qed uses [RuboCop]. RuboCop runs as part of the `lint`

--- a/Rakefile
+++ b/Rakefile
@@ -90,22 +90,3 @@ task :test do
 end
 
 Bundler::Audit::Task.new
-
-namespace :release do
-  link_check_files = FileList.new('**/*.md') do |f|
-    f.exclude('node_modules/**/*')
-    f.exclude('**/target/**/*')
-    f.exclude('**/vendor/*/**/*')
-    f.include('*.md')
-    f.include('**/vendor/*.md')
-  end
-
-  link_check_files.sort.uniq.each do |markdown|
-    desc 'Check for broken links in markdown files'
-    task markdown_link_check: markdown do
-      command = ['npx', 'markdown-link-check', '--config', '.github/markdown-link-check.json', markdown]
-      sh command.shelljoin
-      sleep(rand(1..5))
-    end
-  end
-end


### PR DESCRIPTION
This CI job is incredibly flaky and provides little value. Remove it to reduce maintenance burden.

Followup to #118 which was prematurely merged.